### PR TITLE
Error handling

### DIFF
--- a/pages/api/generate.ts
+++ b/pages/api/generate.ts
@@ -41,7 +41,7 @@ const handler = async (req: Request): Promise<Response> => {
             },
             {
                 "role": "user",
-                "content": "Please create html code with inline css what create the following component, Meterial UI look and feel, return only code"
+                "content": "Please create html code with inline css what create the following component, Material UI look and feel, return only code"
             },
             {"role": "user", "content": "DO NOT wrap the returned code with ```"},
             {"role": "user", "content": prompt},

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -28,6 +28,8 @@ const Home: NextPage = () => {
     const [loading, setLoading] = useState(false);
     const [prompt, setPrompt] = useState("");
     const [generatedCode, setGeneratedCode] = useState<any>("");
+    const [error, setError] = useState(false);
+    const [errorMessage, setErrorMessage] = useState("");
     const { t } = useTranslation('common');
 
     const generateUI = async (e: any) => {
@@ -46,7 +48,13 @@ const Home: NextPage = () => {
         console.log("Edge function returned.");
 
         if (!response.ok) {
-            throw new Error(response.statusText);
+          setError(true);
+          setErrorMessage("Something went wrong!");
+          setLoading(false);
+          console.log(response.statusText);
+          return;
+        } else {
+          setError(false);
         }
 
         // This data is a ReadableStream
@@ -103,13 +111,25 @@ const Home: NextPage = () => {
                     </div>
                     <textarea
                         value={prompt}
-                        onChange={(e) => setPrompt(e.target.value)}
+                        onChange={(e) => {
+                          setPrompt(e.target.value);
+                          setError(false);
+                        }}
                         rows={4}
                         className="w-full rounded-md border-gray-300 shadow-sm focus:border-black focus:ring-black my-5"
                         placeholder={t('exampleInput') || ''}
                     />
 
-                    {!loading && (
+                    {!loading &&
+                      (error ? (
+                        <button
+                          disabled={!prompt}
+                          className="bg-red-600 rounded-xl text-white font-medium px-4 py-2 sm:mt-10 mt-8 hover:bg-red-700 w-full"
+                          onClick={(e) => generateUI(e)}
+                        >
+                          <p>{errorMessage}</p>
+                        </button>
+                      ) : (
                         <button
                             disabled={!prompt}
                             className="bg-black rounded-xl text-white font-medium px-4 py-2 sm:mt-10 mt-8 hover:bg-black/80 w-full"
@@ -117,7 +137,7 @@ const Home: NextPage = () => {
                         >
                             {t('cta')}&rarr;
                         </button>
-                    )}
+                    ))}
                     {loading && (
                         <button
                             className="bg-black rounded-xl text-white font-medium px-4 py-2 sm:mt-10 mt-8 hover:bg-black/80 w-full"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,6 +32,33 @@ const Home: NextPage = () => {
     const [errorMessage, setErrorMessage] = useState("");
     const { t } = useTranslation('common');
 
+    const handleError = (e: Response) => {
+        if (e.ok) {
+            setError(false);
+            return;
+        } else {
+            console.error(e.statusText);
+            switch (e.status) {
+                case 400:
+                    setErrorMessage("There was an error with the request.");
+                    break;
+                case 500:
+                    setErrorMessage("OpenAI API error.");
+                    break;
+                case 502:
+                    setErrorMessage("Gateway error.");
+                    break;
+                case 503:
+                    setErrorMessage("Service unavailable.");
+                    break;
+                default:
+                    setErrorMessage("Something went wrong!");
+            }
+            setError(true);
+            setLoading(false);
+        }
+    };
+
     const generateUI = async (e: any) => {
         e.preventDefault();
         setGeneratedCode("");
@@ -47,15 +74,7 @@ const Home: NextPage = () => {
         });
         console.log("Edge function returned.");
 
-        if (!response.ok) {
-          setError(true);
-          setErrorMessage("Something went wrong!");
-          setLoading(false);
-          console.log(response.statusText);
-          return;
-        } else {
-          setError(false);
-        }
+        handleError(response);
 
         // This data is a ReadableStream
         const data = response.body;


### PR DESCRIPTION
I have added a way to know when an error has occurred, since I was sometimes getting 502's that were only getting logged to the console while the button was still loading.

The button turns red whenever something happens, and goes back to normal as soon as something is typed in the textarea. It is still clickable in that state, to allow retrying the prompt.