### PR TITLE
[UI] fix when the text too long, it will cover the arrow in the select

### DIFF
--- a/components/ExportSelection.tsx
+++ b/components/ExportSelection.tsx
@@ -29,7 +29,7 @@ export default function ExportSelection({ onSelectedExport }) {
                 id="select-option"
                 value={selectedOption}
                 onChange={handleChange}
-                className="px-4 py-2 text-gray-700 bg-white border border-gray-400 rounded-md focus:outline-none focus:border-purple-500"
+                className="pl-4 pl-5 py-2 text-gray-700 bg-white border border-gray-400 rounded-md focus:outline-none focus:border-purple-500"
             >
                 {FRAMEWORKS.map((option) => (
                     <option key={option.value} value={option.value}>


### PR DESCRIPTION
Fixed a small UI issue, when the user selects the Next.js + Tailwind CSS option, it will cover the arrow.


![Screenshot 2023-03-15 000042](https://user-images.githubusercontent.com/4032158/225008887-d2022fee-47d7-40cb-910c-d8bfd57d1c2f.png)
